### PR TITLE
Avoid connection-pool-poisoning by leaning on the exception handling …

### DIFF
--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -53,6 +53,34 @@ library
     -- data:
     time >= 1.5 && < 2,
     -- general:
-    base-prelude >= 1 && < 2,
-    -- exceptions (from base):
-    base >= 4.0 && < 5
+    base-prelude >= 1 && < 2
+
+
+test-suite test
+  type:
+    exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  main-is:
+    Main.hs
+  other-modules:
+    Hasql.PoolSpec
+    Hasql.Prelude
+  default-extensions:
+    Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFoldable, DeriveFunctor, DeriveGeneric, DeriveTraversable, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, LambdaCase, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators, UnboxedTuples
+  default-language:
+    Haskell2010
+  build-depends:
+    hasql-pool,
+    -- hasql-pool internals:
+    resource-pool >= 0.2 && < 0.3,
+    -- database:
+    hasql >= 1.3 && < 1.4,
+    -- data:
+    -- text >= 1.2 && < 1.3,
+    -- testing:
+    hspec >= 2.6 && < 2.7,
+    tasty-hspec >= 1.1 && < 1.2,
+    tasty >= 1.2 && < 1.3,
+    -- general:
+    base-prelude >= 1 && < 2

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -53,4 +53,6 @@ library
     -- data:
     time >= 1.5 && < 2,
     -- general:
-    base-prelude >= 1 && < 2
+    base-prelude >= 1 && < 2,
+    -- exceptions (from base):
+    base >= 4.0 && < 5

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -1,6 +1,6 @@
 module Hasql.Pool
 (
-  Pool,
+  Pool(..),
   Settings(..),
   acquire,
   release,
@@ -9,7 +9,6 @@ module Hasql.Pool
 )
 where
 
-import Control.Exception (Exception, throwIO, catch)
 import Hasql.Pool.Prelude
 import qualified Hasql.Connection
 import qualified Hasql.Session

--- a/test/Hasql/PoolSpec.hs
+++ b/test/Hasql/PoolSpec.hs
@@ -1,0 +1,50 @@
+module Hasql.PoolSpec
+  ( spec
+  ) where
+
+import           Test.Hspec
+
+import qualified Data.Pool
+import qualified Hasql.Connection
+import qualified Hasql.Decoders   as Decoders
+import qualified Hasql.Encoders   as Encoders
+import           Hasql.Pool
+import           Hasql.Prelude
+import           Hasql.Session
+import           Hasql.Statement
+
+testPool :: IORef ResourceEvent -> IO Pool
+testPool ioRef =
+  Pool <$>
+  Data.Pool.createPool
+    onCreateResource
+    onDestroyResource
+    stripes
+    seconds
+    poolSize
+  where
+    onCreateResource =
+      Hasql.Connection.acquire -- make an actual connection attempt resulting in a `Left ConnectionError`
+        "host=unresolvable-address port=5432 dbname=mydb connect_timeout=1"
+    onDestroyResource = const (atomicWriteIORef ioRef Destroyed)
+    stripes = 1
+    seconds = 2
+    poolSize = 1
+
+data ResourceEvent
+  = Created
+  | Destroyed
+  deriving (Show, Eq)
+
+spec :: Spec
+spec =
+  describe "Hasql.Pool.use" $ do
+    it
+      "releases a connection back into the pool when resource in pool is a Left" $ do
+      ioRef <- (newIORef Created :: IO (IORef ResourceEvent)) -- a resource in the pool to observe on
+      p <- testPool ioRef -- put it in a Hasql.Pool.Pool
+      _ <- use p testSession -- trigger use
+      readIORef ioRef `shouldReturn` Destroyed -- expectation
+  where
+    testStatement = Statement "" Encoders.unit Decoders.unit True
+    testSession = statement () testStatement

--- a/test/Hasql/Prelude.hs
+++ b/test/Hasql/Prelude.hs
@@ -1,0 +1,10 @@
+module Hasql.Prelude
+( 
+  module Exports,
+)
+where
+
+
+-- base-prelude
+-------------------------
+import BasePrelude as Exports

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import           Test.Tasty
+import           Test.Tasty.Hspec
+
+import           Hasql.Prelude
+import qualified Hasql.PoolSpec
+
+main = tests >>= defaultMain
+
+tests :: IO TestTree
+tests = testSpec "Hasql.Pool" Hasql.PoolSpec.spec


### PR DESCRIPTION
…inside Data.Pool.withResource

Firstly, TY for your great SQL-libraries!

This PR resolves the issue of `Hasql.Connection.ConnectionError` being returned to the `Data.Pool`. `Data.Pool.withResource` uses an `onException` which is not invoked on a `Left` value, so in order for the pool resource destruction to take place, one has to actually throw an Exception.