### PR TITLE
ResourcePool: destroy resource on exception

### DIFF
--- a/library/Hasql/Pool/ResourcePool.hs
+++ b/library/Hasql/Pool/ResourcePool.hs
@@ -11,7 +11,7 @@ import Data.Pool
 withResourceOnEither :: Pool resource -> (resource -> IO (Either failure success)) -> IO (Either failure success)
 withResourceOnEither pool act = mask_ $ do
   (resource, localPool) <- takeResource pool
-  failureOrSuccess <- act resource
+  failureOrSuccess <- act resource `onException` destroyResource pool localPool resource
   case failureOrSuccess of
     Right success -> do
       putResource localPool resource


### PR DESCRIPTION
Before this change, IO-based exceptions in the session (`act`)
caused the connection to "used" indefinitely; not returning capacity
to the pool, eventually depleting the pool.

This PR is a conservative fix for the problem. I recommend to use `withResource` from the `resource-pool` package itself. It is more widely used and it does not have this problem. Additionally it unmasks exceptions for sessions. Do you think masking async exceptions is appropriate for sessions?
