### PR TITLE
Add support for flushing the pool

### DIFF
--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -3,6 +3,7 @@ module Hasql.Pool
     Pool,
     acquire,
     acquireDynamically,
+    flush,
     release,
     use,
 
@@ -28,8 +29,11 @@ data Pool = Pool
     -- of length poolConnectionQueue and the number of in-flight
     -- connections.
     poolCapacity :: TVar Int,
-    -- | Alive.
-    poolAlive :: TVar Bool
+    -- | Liveness state of the current generation.
+    -- The pool as a whole is alive if the current generation is alive,
+    -- while a connection is returned to the pool if the generation it
+    -- was acquired in is still alive.
+    poolAlive :: TVar (TVar Bool)
   }
 
 -- | Given the pool-size and connection settings create a connection-pool.
@@ -53,7 +57,7 @@ acquireDynamically poolSize fetchConnectionSettings = do
   Pool fetchConnectionSettings
     <$> newTQueueIO
     <*> newTVarIO poolSize
-    <*> newTVarIO True
+    <*> (newTVarIO =<< newTVarIO True)
 
 -- | Release all the idle connections in the pool and mark the pool as dead.
 -- In-use connections will survive this and be closed once they would be returned
@@ -61,9 +65,27 @@ acquireDynamically poolSize fetchConnectionSettings = do
 release :: Pool -> IO ()
 release Pool {..} = do
   connections <- atomically $ do
-    writeTVar poolAlive False
+    alive <- readTVar poolAlive
+    writeTVar alive False
     flushTQueue poolConnectionQueue
   forM_ connections Connection.release
+
+-- | Flush the pool, so that using the pool doesn't reuse any connection from
+-- before the call. Release all the idle connections in the pool, and mark
+-- in-use connections to be closed once they would be returned.
+flush :: Pool -> IO ()
+flush Pool {..} =
+  join . atomically $ do
+    prevAlive <- readTVar poolAlive
+    alive <- readTVar prevAlive
+    if alive
+      then do
+        writeTVar prevAlive False
+        writeTVar poolAlive =<< newTVar True
+        conns <- flushTQueue poolConnectionQueue
+        modifyTVar' poolCapacity (+ (length conns))
+        return $ forM_ conns Connection.release
+      else return (return ())
 
 -- | Use a connection from the pool to run a session and return the connection
 -- to the pool, when finished.
@@ -75,30 +97,31 @@ release Pool {..} = do
 use :: Pool -> Session.Session a -> IO (Either UsageError a)
 use Pool {..} sess =
   join . atomically $ do
-    alive <- readTVar poolAlive
+    aliveVar <- readTVar poolAlive
+    alive <- readTVar aliveVar
     if alive
-      then
+      then do
         asum
-          [ readTQueue poolConnectionQueue <&> onConn,
+          [ readTQueue poolConnectionQueue <&> onConn aliveVar,
             do
               capVal <- readTVar poolCapacity
               if capVal > 0
                 then do
                   writeTVar poolCapacity $! pred capVal
-                  return onNewConn
+                  return $ onNewConn aliveVar
                 else retry
           ]
       else return . return . Left $ PoolIsReleasedUsageError
   where
-    onNewConn = do
+    onNewConn aliveVar = do
       settings <- poolFetchConnectionSettings
       connRes <- Connection.acquire settings
       case connRes of
         Left connErr -> do
           atomically $ modifyTVar' poolCapacity succ
           return $ Left $ ConnectionUsageError connErr
-        Right conn -> onConn conn
-    onConn conn = do
+        Right conn -> onConn aliveVar conn
+    onConn aliveVar conn = do
       sessRes <- Session.run sess conn
       case sessRes of
         Left err -> case err of
@@ -114,10 +137,12 @@ use Pool {..} sess =
       where
         returnConn =
           join . atomically $ do
-            alive <- readTVar poolAlive
+            alive <- readTVar aliveVar
             if alive
               then writeTQueue poolConnectionQueue conn $> return ()
-              else return $ Connection.release conn
+              else do
+                modifyTVar' poolCapacity succ
+                return $ Connection.release conn
 
 -- | Union over all errors that 'use' can result in.
 data UsageError

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -58,6 +58,19 @@ main = hspec $ do
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
       res2 `shouldBe` Right (Just "hello world")
+    it "Flushing the pool resets session variables" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ setSettingSession "testing.foo" "hello world"
+      res `shouldBe` Right ()
+      flush pool
+      res <- use pool $ getSettingSession "testing.foo"
+      res `shouldBe` Right Nothing
+    it "Flushing a released pool leaves it dead" $ do
+      pool <- acquire 1 connectionSettings
+      release pool
+      flush pool
+      res <- use pool $ selectOneSession
+      res `shouldBe` Left PoolIsReleasedUsageError
 
 connectionSettings :: Connection.Settings
 connectionSettings =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -44,6 +44,12 @@ main = hspec $ do
       res <- use pool $ badQuerySession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
+    it "The pool remains usable after release" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ selectOneSession
+      release pool
+      res <- use pool $ selectOneSession
+      shouldSatisfy res $ isRight
     it "Getting and setting session variables works" $ do
       pool <- acquire 1 connectionSettings
       res <- use pool $ getSettingSession "testing.foo"
@@ -58,19 +64,13 @@ main = hspec $ do
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
       res2 `shouldBe` Right (Just "hello world")
-    it "Flushing the pool resets session variables" $ do
+    it "Releasing the pool resets session variables" $ do
       pool <- acquire 1 connectionSettings
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
-      flush pool
+      release pool
       res <- use pool $ getSettingSession "testing.foo"
       res `shouldBe` Right Nothing
-    it "Flushing a released pool leaves it dead" $ do
-      pool <- acquire 1 connectionSettings
-      release pool
-      flush pool
-      res <- use pool $ selectOneSession
-      res `shouldBe` Left PoolIsReleasedUsageError
 
 connectionSettings :: Connection.Settings
 connectionSettings =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -44,6 +44,20 @@ main = hspec $ do
       res <- use pool $ badQuerySession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
+    it "Getting and setting session variables works" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ getSettingSession "testing.foo"
+      res `shouldBe` Right Nothing
+      res <- use pool $ do
+        setSettingSession "testing.foo" "hello world"
+        getSettingSession "testing.foo"
+      res `shouldBe` Right (Just "hello world")
+    it "Session variables stay set when a connection gets reused" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ setSettingSession "testing.foo" "hello world"
+      res `shouldBe` Right ()
+      res2 <- use pool $ getSettingSession "testing.foo"
+      res2 `shouldBe` Right (Just "hello world")
 
 connectionSettings :: Connection.Settings
 connectionSettings =
@@ -66,3 +80,20 @@ closeConnSession :: Session.Session ()
 closeConnSession = do
   conn <- ask
   liftIO $ Connection.release conn
+
+setSettingSession :: Text -> Text -> Session.Session ()
+setSettingSession name value = do
+  Session.statement (name, value) statement
+  where
+    statement = Statement.Statement "SELECT set_config($1, $2, false)" encoder Decoders.noResult True
+    encoder =
+      contramap fst (Encoders.param (Encoders.nonNullable Encoders.text))
+        <> contramap snd (Encoders.param (Encoders.nonNullable Encoders.text))
+
+getSettingSession :: Text -> Session.Session (Maybe Text)
+getSettingSession name = do
+  Session.statement name statement
+  where
+    statement = Statement.Statement "SELECT current_setting($1, true)" encoder decoder True
+    encoder = Encoders.param (Encoders.nonNullable Encoders.text)
+    decoder = Decoders.singleRow (Decoders.column (Decoders.nullable Decoders.text))


### PR DESCRIPTION
"Flushing the pool" is close to what "releasing the pool" did in versions < 0.6, except it also ensures that in-flight connections don't get returned to the pool.

Does this seem like a useful feature? I fully understand if you'd prefer to keep the library simpler.

For context, I'm trying to upgrade PostgREST from hasql-pool 0.5, and PostgREST relies (brokenly) on being able to flush the pool via `release`. That's because it sets some per-connection variables, and needs to be able to update those values for new requests. (I make no claims as to whether that's a particularly sensible approach.)

This isn't necessarily the simplest/cleanest way to do it. An alternative I'm aware of would be to track e.g. a `poolGeneration :: TVar Int` and compare the acquisition generation to the current generation to determine whether to return a connection to the pool. That has the theoretical downside that `Int` is bounded...