### PR TITLE
Acquisition timeout

### DIFF
--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -43,9 +43,11 @@ test-suite test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Main.hs
+  ghc-options: -threaded
   build-depends:
     hasql,
     hasql-pool,
+    async,
     hspec >=2.6 && <3,
     rerebase >=1.15 && <2,
     stm >=2.5 && <3,

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -3,6 +3,7 @@ module Hasql.Pool
     Pool,
     acquire,
     acquireDynamically,
+    flush,
     release,
     use,
 
@@ -28,8 +29,11 @@ data Pool = Pool
     -- of length poolConnectionQueue and the number of in-flight
     -- connections.
     poolCapacity :: TVar Int,
-    -- | Alive.
-    poolAlive :: TVar Bool
+    -- | Liveness state of the current generation.
+    -- The pool as a whole is alive if the current generation is alive,
+    -- while a connection is returned to the pool if the generation it
+    -- was acquired in is still alive.
+    poolAlive :: TVar (TVar Bool)
   }
 
 -- | Given the pool-size and connection settings create a connection-pool.
@@ -53,7 +57,7 @@ acquireDynamically poolSize fetchConnectionSettings = do
   Pool fetchConnectionSettings
     <$> newTQueueIO
     <*> newTVarIO poolSize
-    <*> newTVarIO True
+    <*> (newTVarIO =<< newTVarIO True)
 
 -- | Release all the idle connections in the pool and mark the pool as dead.
 -- In-use connections will survive this and be closed once they would be returned
@@ -61,9 +65,27 @@ acquireDynamically poolSize fetchConnectionSettings = do
 release :: Pool -> IO ()
 release Pool {..} = do
   connections <- atomically $ do
-    writeTVar poolAlive False
+    alive <- readTVar poolAlive
+    writeTVar alive False
     flushTQueue poolConnectionQueue
   forM_ connections Connection.release
+
+-- | Flush the pool, so that using the pool doesn't reuse any connection from
+-- before the call. Release all the idle connections in the pool, and mark
+-- in-use connections to be closed once they would be returned.
+flush :: Pool -> IO ()
+flush Pool {..} =
+  join . atomically $ do
+    prevAlive <- readTVar poolAlive
+    alive <- readTVar prevAlive
+    if alive
+      then do
+        writeTVar prevAlive False
+        writeTVar poolAlive =<< newTVar True
+        conns <- flushTQueue poolConnectionQueue
+        modifyTVar' poolCapacity (+ (length conns))
+        return $ forM_ conns Connection.release
+      else return (return ())
 
 -- | Use a connection from the pool to run a session and return the connection
 -- to the pool, when finished.
@@ -75,30 +97,31 @@ release Pool {..} = do
 use :: Pool -> Session.Session a -> IO (Either UsageError a)
 use Pool {..} sess =
   join . atomically $ do
-    alive <- readTVar poolAlive
+    aliveVar <- readTVar poolAlive
+    alive <- readTVar aliveVar
     if alive
-      then
+      then do
         asum
-          [ readTQueue poolConnectionQueue <&> onConn,
+          [ readTQueue poolConnectionQueue <&> onConn aliveVar,
             do
               capVal <- readTVar poolCapacity
               if capVal > 0
                 then do
                   writeTVar poolCapacity $! pred capVal
-                  return onNewConn
+                  return $ onNewConn aliveVar
                 else retry
           ]
       else return . return . Left $ PoolIsReleasedUsageError
   where
-    onNewConn = do
+    onNewConn aliveVar = do
       settings <- poolFetchConnectionSettings
       connRes <- Connection.acquire settings
       case connRes of
         Left connErr -> do
           atomically $ modifyTVar' poolCapacity succ
           return $ Left $ ConnectionUsageError connErr
-        Right conn -> onConn conn
-    onConn conn = do
+        Right conn -> onConn aliveVar conn
+    onConn aliveVar conn = do
       sessRes <- Session.run sess conn
       case sessRes of
         Left err -> case err of
@@ -114,10 +137,12 @@ use Pool {..} sess =
       where
         returnConn =
           join . atomically $ do
-            alive <- readTVar poolAlive
+            alive <- readTVar aliveVar
             if alive
               then writeTQueue poolConnectionQueue conn $> return ()
-              else return $ Connection.release conn
+              else do
+                modifyTVar' poolCapacity succ
+                return $ Connection.release conn
 
 -- | Union over all errors that 'use' can result in.
 data UsageError

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -58,6 +58,19 @@ main = hspec $ do
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
       res2 `shouldBe` Right (Just "hello world")
+    it "Flushing the pool resets session variables" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ setSettingSession "testing.foo" "hello world"
+      res `shouldBe` Right ()
+      flush pool
+      res <- use pool $ getSettingSession "testing.foo"
+      res `shouldBe` Right Nothing
+    it "Flushing a released pool leaves it dead" $ do
+      pool <- acquire 1 connectionSettings
+      release pool
+      flush pool
+      res <- use pool $ selectOneSession
+      res `shouldBe` Left PoolIsReleasedUsageError
 
 connectionSettings :: Connection.Settings
 connectionSettings =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -44,6 +44,12 @@ main = hspec $ do
       res <- use pool $ badQuerySession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
+    it "The pool remains usable after release" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ selectOneSession
+      release pool
+      res <- use pool $ selectOneSession
+      shouldSatisfy res $ isRight
     it "Getting and setting session variables works" $ do
       pool <- acquire 1 connectionSettings
       res <- use pool $ getSettingSession "testing.foo"
@@ -58,19 +64,13 @@ main = hspec $ do
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
       res2 `shouldBe` Right (Just "hello world")
-    it "Flushing the pool resets session variables" $ do
+    it "Releasing the pool resets session variables" $ do
       pool <- acquire 1 connectionSettings
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
-      flush pool
+      release pool
       res <- use pool $ getSettingSession "testing.foo"
       res `shouldBe` Right Nothing
-    it "Flushing a released pool leaves it dead" $ do
-      pool <- acquire 1 connectionSettings
-      release pool
-      flush pool
-      res <- use pool $ selectOneSession
-      res `shouldBe` Left PoolIsReleasedUsageError
 
 connectionSettings :: Connection.Settings
 connectionSettings =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -44,6 +44,20 @@ main = hspec $ do
       res <- use pool $ badQuerySession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
+    it "Getting and setting session variables works" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ getSettingSession "testing.foo"
+      res `shouldBe` Right Nothing
+      res <- use pool $ do
+        setSettingSession "testing.foo" "hello world"
+        getSettingSession "testing.foo"
+      res `shouldBe` Right (Just "hello world")
+    it "Session variables stay set when a connection gets reused" $ do
+      pool <- acquire 1 connectionSettings
+      res <- use pool $ setSettingSession "testing.foo" "hello world"
+      res `shouldBe` Right ()
+      res2 <- use pool $ getSettingSession "testing.foo"
+      res2 `shouldBe` Right (Just "hello world")
 
 connectionSettings :: Connection.Settings
 connectionSettings =
@@ -66,3 +80,20 @@ closeConnSession :: Session.Session ()
 closeConnSession = do
   conn <- ask
   liftIO $ Connection.release conn
+
+setSettingSession :: Text -> Text -> Session.Session ()
+setSettingSession name value = do
+  Session.statement (name, value) statement
+  where
+    statement = Statement.Statement "SELECT set_config($1, $2, false)" encoder Decoders.noResult True
+    encoder =
+      contramap fst (Encoders.param (Encoders.nonNullable Encoders.text))
+        <> contramap snd (Encoders.param (Encoders.nonNullable Encoders.text))
+
+getSettingSession :: Text -> Session.Session (Maybe Text)
+getSettingSession name = do
+  Session.statement name statement
+  where
+    statement = Statement.Statement "SELECT current_setting($1, true)" encoder decoder True
+    encoder = Encoders.param (Encoders.nonNullable Encoders.text)
+    decoder = Decoders.singleRow (Decoders.column (Decoders.nullable Decoders.text))


### PR DESCRIPTION
This introduces an acquisition timeout, making it possible to bail out of waiting for a connection cleanly. (Includes the changes from #16 to avoid dealing with conflicts, happy to rebase with only this change though if preferred.)

We want something like this for PostgREST (https://github.com/PostgREST/postgrest/issues/2348) to be able to actively time out queries that are blocked waiting for an overloaded connection pool.

- This times out only the "blocking for a slot" part of connection acquisition, not establishing the connection. (I think that's probably the cleaner approch, but it's a point to consider.)
- Some alternative ideas of approaching this that wouldn't need changes to `hasql-pool`:
  - Just put a `timeout` on the whole action (i.e. `timeout delay $ Pool.use $ query`). Undesirable because it might mean interrupting while the query is running database server side, running into problems like returning a timeout error while postgres might still successfully apply the request.
  - A disarmable timeout (i.e. `disarmableTimeout delay $ \disarm -> Pool.use $ disarm >> query`). That should work, it's just tricky to get right and pretty complicated and I'd rather avoid going there. 😬