### PR TITLE
rename Close to avoid name ambiguity, fixing Windows build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0.2
+
+Fixed Windows build.
+
 # 0.8
 
 `release` became reusable. You can use it to destroy the whole pool (same as before), but now also you can use it to reset the connections.

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: hasql-pool
-version: 0.8.0.1
+version: 0.8.0.2
 
 category: Hasql, Database, PostgreSQL
 synopsis: Pool of connections for Hasql

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -29,7 +29,7 @@ data Pool = Pool
     poolConnectionQueue :: TQueue Connection,
     -- | Remaining capacity.
     -- The pool size limits the sum of poolCapacity, the length
-    -- of length poolConnectionQueue and the number of in-flight
+    -- of poolConnectionQueue and the number of in-flight
     -- connections.
     poolCapacity :: TVar Int,
     -- | Whether to return a connection to the pool.

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -17,8 +17,6 @@ import Hasql.Pool.Prelude
 import Hasql.Session (Session)
 import qualified Hasql.Session as Session
 
-data ReuseConnection = Keep | Close
-
 -- | Pool of connections to DB.
 data Pool = Pool
   { -- | Connection settings.
@@ -33,7 +31,7 @@ data Pool = Pool
     -- connections.
     poolCapacity :: TVar Int,
     -- | Whether to return a connection to the pool.
-    poolReuseToggle :: TVar (TVar ReuseConnection)
+    poolReuse :: TVar (TVar Bool)
   }
 
 -- | Create a connection-pool.
@@ -70,7 +68,7 @@ acquireDynamically poolSize timeout fetchConnectionSettings = do
   Pool fetchConnectionSettings timeout
     <$> newTQueueIO
     <*> newTVarIO poolSize
-    <*> (newTVarIO =<< newTVarIO Keep)
+    <*> (newTVarIO =<< newTVarIO True)
 
 -- | Release all the idle connections in the pool, and mark the in-use connections
 -- to be released on return. Any connections acquired after the call will be
@@ -78,10 +76,10 @@ acquireDynamically poolSize timeout fetchConnectionSettings = do
 release :: Pool -> IO ()
 release Pool {..} =
   join . atomically $ do
-    prevReuseToggle <- readTVar poolReuseToggle
-    writeTVar prevReuseToggle Close
-    newReuseToggle <- newTVar Keep
-    writeTVar poolReuseToggle newReuseToggle
+    prevReuse <- readTVar poolReuse
+    writeTVar prevReuse False
+    newReuse <- newTVar True
+    writeTVar poolReuse newReuse
     conns <- flushTQueue poolConnectionQueue
     modifyTVar' poolCapacity (+ (length conns))
     return $ forM_ conns Connection.release
@@ -102,15 +100,15 @@ use Pool {..} sess = do
     Nothing ->
       return $ return False
   join . atomically $ do
-    reuseToggle <- readTVar poolReuseToggle
+    reuseVar <- readTVar poolReuse
     asum
-      [ readTQueue poolConnectionQueue <&> onConn reuseToggle,
+      [ readTQueue poolConnectionQueue <&> onConn reuseVar,
         do
           capVal <- readTVar poolCapacity
           if capVal > 0
             then do
               writeTVar poolCapacity $! pred capVal
-              return $ onNewConn reuseToggle
+              return $ onNewConn reuseVar
             else retry,
         do
           timedOut <- timeout
@@ -119,15 +117,15 @@ use Pool {..} sess = do
             else retry
       ]
   where
-    onNewConn reuseToggle = do
+    onNewConn reuseVar = do
       settings <- poolFetchConnectionSettings
       connRes <- Connection.acquire settings
       case connRes of
         Left connErr -> do
           atomically $ modifyTVar' poolCapacity succ
           return $ Left $ ConnectionUsageError connErr
-        Right conn -> onConn reuseToggle conn
-    onConn reuseToggle conn = do
+        Right conn -> onConn reuseVar conn
+    onConn reuseVar conn = do
       sessRes <- Session.run sess conn
       case sessRes of
         Left err -> case err of
@@ -143,10 +141,10 @@ use Pool {..} sess = do
       where
         returnConn =
           join . atomically $ do
-            reuse <- readTVar reuseToggle
-            case reuse of
-              Keep -> writeTQueue poolConnectionQueue conn $> return ()
-              Close -> do
+            reuse <- readTVar reuseVar
+            if reuse
+              then writeTQueue poolConnectionQueue conn $> return ()
+              else do
                 modifyTVar' poolCapacity succ
                 return $ Connection.release conn
 


### PR DESCRIPTION
Somehow, we import GHC.Event.Windows.ConsoleEvent.Close on Windows
via Hasql.Pool.Prelude, which conflicts with Close.

- might be nicer to avoid that import, but I couldn't figure out where it even comes from precisely (and I wouldn't want to conditionally hide an import based on CPP...)
- should Windows be added to CI to verify this / prevent it in the future?

See this PostgREST CI failure: https://pipelines.actions.githubusercontent.com/serviceHosts/996fe3a3-010d-4e7c-a003-8e967bc4327c/_apis/pipelines/1/runs/2550/signedlogcontent/2?urlExpires=2022-08-30T06%3A30%3A28.3317426Z&urlSigningMethod=HMACV1&urlSignature=hCE13v%2Fp7jkakftXs%2FRp%2FY1EkmZVfgiucJpcj1kcobA%3D

```
2022-08-30T00:12:23.7448486Z [0mhasql-pool                   > [;1mlibrary\Hasql\Pool.hs:82:31: [;1m[31merror:[0m[0m[;1m[0m[0m[;1m[0m
2022-08-30T00:12:23.7613309Z [0mhasql-pool                   >     Ambiguous occurrence `Close'[0m
2022-08-30T00:12:23.7625695Z [0mhasql-pool                   >     It could refer to[0m
2022-08-30T00:12:23.7647920Z [0mhasql-pool                   >        either `Hasql.Pool.Prelude.Close',[0m
2022-08-30T00:12:23.7650835Z [0mhasql-pool                   >               imported from `Hasql.Pool.Prelude' at library\Hasql\Pool.hs:16:1-25[0m
2022-08-30T00:12:23.7653713Z [0mhasql-pool                   >               (and originally defined in `GHC.Event.Windows.ConsoleEvent')[0m
2022-08-30T00:12:23.7655989Z [0mhasql-pool                   >            or `Hasql.Pool.Close', defined at library\Hasql\Pool.hs:20:31[0m[0m[0m
2022-08-30T00:12:23.7660646Z [0mhasql-pool                   > [;1m[34m   |[0m[0m[0m
2022-08-30T00:12:23.7674845Z [0mhasql-pool                   > [;1m[34m82 |[0m[0m     writeTVar prevReuseToggle [;1m[31mClose[0m[0m[0m
2022-08-30T00:12:23.7675918Z [0mhasql-pool                   > [;1m[34m   |[0m[0m[;1m[31m                               ^^^^^[0m[0m
```