### PR TITLE
Add Windows build to CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-test:
     strategy:
       matrix:
         ghc: ['8.10.7', '9.2.4']
@@ -58,3 +58,35 @@ jobs:
       run: |
         export POSTGRES_PASSWORD=postgres
         cabal test all
+
+  build-windows:
+    strategy:
+      matrix:
+        ghc: ['8.10.7', '9.2.4']
+      fail-fast: false
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: ghcup
+      run: |
+        ghcup install ghc ${{ matrix.ghc }}
+        ghcup set ghc ${{ matrix.ghc }}
+        ghcup install cabal latest
+        ghcup set cabal latest
+
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build --enable-tests --enable-benchmarks all


### PR DESCRIPTION
This came out of #20, where I couldn't make this job work. Filing here so it's not lost.

- currently fails because of missing `libpq`, and I don't know how to install that on Windows (PostgREST does something with `Add-Content` here: https://github.com/PostgREST/postgrest/blob/81f42d4b8a19587167cd00dfbc79b01a8c644df3/.github/workflows/ci.yaml#L171
- I'm not sure what the correct path to cache is