### PR TITLE
Catches session exceptions

### DIFF
--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: hasql-pool
-version: 0.8.0.4
+version: 0.8.0.5
 
 category: Hasql, Database, PostgreSQL
 synopsis: Pool of connections for Hasql


### PR DESCRIPTION
[Issue #25](https://github.com/nikita-volkov/hasql-pool/issues/25) 

I ran into an issue that if there was an exception thrown from a session, the pool does not return the connection or capacity to the pool and the pool can run out of connections!

This change has two parts:

1. Catch session errors and surfaces them as `SessionUsageError`s in the return value so it can be handled by existing logic on whether to reuse the connection or not.
2. Catch other errors, returns the capacity to the pool, then re-throws the exception.

The first point is just to make sure that the errors we want to surface in the return are handled. Maybe they can never be thrown in normal usage, but with things like `hasql-transaction-io` you can get some very creative errors.

The second is the meat of the change.  It catches other errors and makes sure capacity is returned to the pool.  I opted not to return the connection in case the error was some sort of error indicating that the connection was no longer valid.

I tested this by running a session that was:

```haskell
(use pool $ error "Query 1") `catch` \(e :: SomeException) -> use pool $ error "Query 2"
```

Without the change it would hang on the second query.  With this change it threw the second error.