### PR TITLE
add max connection lifetime option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.9
 
-Connections now have a configurable maximal lifetime, configurable via a new extensible configuration interface. The pool is now actively managed, and is created using a combinator that takes care to free resources after use.
+Connections now have a maximal lifetime, defaulting to 30m and configurable via a new extensible configuration interface. The pool is now actively managed, and is created using a combinator that takes care to free resources after use. The acquisition timeout is now also non-optional, defaulting to 10s.
 
 Breaking changes in API:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.9
+
+Connections now have a configurable maximal lifetime, configurable via a new extensible configuration interface. The pool is now actively managed, and is created using a combinator that takes care to free resources after use.
+
+Breaking changes in API:
+
+- `acquire` and `acquireDynamically` are replaced with `withPool` and `withPoolConf`
+
 # 0.8.0.7
 
 Fix excessive connections during releases due to race conditions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-# 0.9
+# 0.8.1
 
-Connections now have a maximal lifetime, defaulting to 30m and configurable via a new extensible configuration interface. The pool is now actively managed, and is created using a combinator that takes care to free resources after use. The acquisition timeout is now also non-optional, defaulting to 10s.
+Connections now have a maximal lifetime, defaulting to 30m and configurable via a new extensible configuration interface. The acquisition timeout is now also non-optional, defaulting to 10s.
 
-Breaking changes in API:
-
-- `acquire` and `acquireDynamically` are replaced with `withPool` and `withPoolConf`
+Adds `Config`, various setters and `acquireConf`.
 
 # 0.8.0.7
 

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -46,5 +46,6 @@ test-suite test
     hasql,
     hasql-pool,
     hspec >=2.6 && <3,
+    random >= 1.2 && <2,
     rerebase >=1.15 && <2,
     stm >=2.5 && <3,

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: hasql-pool
-version: 0.9
+version: 0.8.1
 
 category: Hasql, Database, PostgreSQL
 synopsis: Pool of connections for Hasql

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: hasql-pool
-version: 0.8.0.7
+version: 0.9
 
 category: Hasql, Database, PostgreSQL
 synopsis: Pool of connections for Hasql

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -32,6 +32,7 @@ library
   build-depends:
     base >=4.11 && <5,
     hasql >=1.6.0.1 && <1.7,
+    async >=2.2 && <3,
     stm >=2.5 && <3,
     transformers >=0.5 && <0.7,
 

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -28,7 +28,6 @@ import Hasql.Pool.Prelude
 import Hasql.Session (Session)
 import qualified Hasql.Session as Session
 
-
 -- | Pool configuration.
 --
 -- This is created by modifying 'defaultConfig' using the various setters,
@@ -48,30 +47,31 @@ data Config = Config
 
 -- | Default pool configuration.
 defaultConfig :: Config
-defaultConfig = Config
-  { confSize = 10,
-    confFetchConnectionSettings = pure "",
-    confAcquisitionTimeout = Nothing,
-    confMaxLifetime = Nothing,
-    confManageInterval = 1000000 -- 1s
-  }
+defaultConfig =
+  Config
+    { confSize = 10,
+      confFetchConnectionSettings = pure "",
+      confAcquisitionTimeout = Nothing,
+      confMaxLifetime = Nothing,
+      confManageInterval = 1000000 -- 1s
+    }
 
 -- | Modify a pool configuration, setting the pool size (default 10).
 --
 -- The pool guarantees that the number of concurrent connections never
 -- exceeds this value.
 setSize :: Int -> Config -> Config
-setSize c config = config { confSize = c }
+setSize c config = config {confSize = c}
 
 -- | Modify a pool configuration, setting a constant connection string. (default "").
 setConnectionSettings :: Connection.Settings -> Config -> Config
-setConnectionSettings s config = config { confFetchConnectionSettings = pure s }
+setConnectionSettings s config = config {confFetchConnectionSettings = pure s}
 
 -- | Modify a pool configuration, setting a dynamic connection string.
 -- When creating a connection, the action will be run to determine the
 -- current connection string.
 setFetchConnectionSettings :: IO Connection.Settings -> Config -> Config
-setFetchConnectionSettings s config = config { confFetchConnectionSettings = s }
+setFetchConnectionSettings s config = config {confFetchConnectionSettings = s}
 
 -- | Modify a pool configuration, setting an acquisition timeout in microseconds. (default 'Nothing', i.e., disabled)
 --
@@ -79,14 +79,14 @@ setFetchConnectionSettings s config = config { confFetchConnectionSettings = s }
 -- with 'AcquisitionTimeoutUsageError' if no connection becomes available
 -- within the timeout.
 setAcquisitionTimeout :: Maybe Int -> Config -> Config
-setAcquisitionTimeout t config = config { confAcquisitionTimeout = t }
+setAcquisitionTimeout t config = config {confAcquisitionTimeout = t}
 
 -- | Modify a pool configuration, setting a maximum connection lifetime, in microseconds. (default 'Nothing', i.e., disabled)
 --
 -- If this timeout is set, then connections will be closed once they
 -- are older than this value (and have been returned to the pool).
 setMaxLifetime :: Maybe Int -> Config -> Config
-setMaxLifetime t config = config { confMaxLifetime = t }
+setMaxLifetime t config = config {confMaxLifetime = t}
 
 -- | Modify a pool configuration, setting the management thread's iteration interval, in microseconds. (Default 1s).
 --
@@ -94,7 +94,7 @@ setMaxLifetime t config = config { confMaxLifetime = t }
 -- setting affects the precision to which e.g. connection lifetime is limited
 -- via 'setMaxLifetime'.
 setManageInterval :: Int -> Config -> Config
-setManageInterval t config = config { confManageInterval = t }
+setManageInterval t config = config {confManageInterval = t}
 
 -- | A connection tagged with metadata.
 data Conn = Conn
@@ -132,8 +132,8 @@ withPool ::
   -- | Connection settings.
   Connection.Settings ->
   -- | Action.
-  (Pool -> IO a)
-  -> IO a
+  (Pool -> IO a) ->
+  IO a
 withPool poolSize connectionSettings = withPoolConf conf
   where
     conf = setSize poolSize . setFetchConnectionSettings (pure connectionSettings) $ defaultConfig
@@ -149,8 +149,8 @@ withPoolConf ::
   -- | Pool configuration.
   Config ->
   -- | Action.
-  (Pool -> IO a)
-  -> IO a
+  (Pool -> IO a) ->
+  IO a
 withPoolConf config inner =
   bracket
     (acquire config)

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -39,7 +39,7 @@ data Conn = Conn
 data Config = Config
   { -- | Pool size (default 10).
     confSize :: Int,
-    -- | Connection settings (default postgres@localhost:5432/postgres).
+    -- | Connection settings (default "").
     confFetchConnectionSettings :: IO Connection.Settings,
     -- | Maximal connection lifetime, in microseconds (default Nothing).
     confMaxLifetime :: Maybe Int,
@@ -53,7 +53,7 @@ data Config = Config
 defaultConfig :: Config
 defaultConfig = Config
   { confSize = 10,
-    confFetchConnectionSettings = pure "host=localhost port=5432 user=postgres database=postgres",
+    confFetchConnectionSettings = pure "",
     confAcquisitionTimeout = Nothing,
     confMaxLifetime = Nothing,
     confManageInterval = 1000000 -- 1s

--- a/library/Hasql/Pool/Prelude.hs
+++ b/library/Hasql/Pool/Prelude.hs
@@ -7,6 +7,7 @@ import Control.Applicative as Exports hiding (WrappedArrow (..))
 import Control.Arrow as Exports hiding (first, second)
 import Control.Category as Exports
 import Control.Concurrent as Exports
+import Control.Concurrent.Async as Exports
 import Control.Concurrent.STM as Exports hiding (orElse)
 import Control.Exception as Exports
 import Control.Monad as Exports hiding (fail, forM, forM_, mapM, mapM_, msum, sequence, sequence_)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -73,7 +73,7 @@ main = do
       res `shouldBe` Right Nothing
     it "Times out connection acquisition" $
       -- 1ms timeout
-      withPoolConf (setSize 1 . setAcquisitionTimeout (Just 1000) $ config) $ \pool -> do
+      withPoolConf (setSize 1 . setAcquisitionTimeout 1000 $ config) $ \pool -> do
         sleeping <- newEmptyMVar
         t0 <- getCurrentTime
         res <-
@@ -92,7 +92,7 @@ main = do
         diffUTCTime t1 t0 `shouldSatisfy` (< 0.5) -- 0.5s
     it "Passively times out old connections" $
       -- 0.5s connection lifetime
-      withPoolConf (setSize 1 . setMaxLifetime (Just 500000) $ config) $ \pool -> do
+      withPoolConf (setSize 1 . setMaxLifetime 500000 $ config) $ \pool -> do
         res <- use pool $ setSettingSession "testing.foo" "hello world"
         res `shouldBe` Right ()
         res2 <- use pool $ getSettingSession "testing.foo"
@@ -109,7 +109,7 @@ main = do
       withPoolConf config $ \countPool -> do
         (taggedConnectionSettings, appName) <- tagConnection connectionSettings
         withPoolConf
-          (setManageInterval 10000 . setMaxLifetime (Just 500000) . setConnectionSettings taggedConnectionSettings $ config)
+          (setManageInterval 10000 . setMaxLifetime 500000 . setConnectionSettings taggedConnectionSettings $ config)
           ( \limitedPool -> do
               res <- use limitedPool $ selectOneSession
               res `shouldBe` Right 1

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,6 +18,7 @@ import Prelude
 main = do
   connectionSettings <- getConnectionSettings
   let config = setSize 3 . setConnectionSettings connectionSettings $ defaultConfig
+      withPoolConf conf = bracket (acquireConf conf) release
 
   hspec . describe "" $ do
     it "Releases a spot in the pool when there is a query error" $ withPoolConf config $ \pool -> do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,52 +20,52 @@ main = do
   let config = setSize 3 . setConnectionSettings connectionSettings $ defaultConfig
 
   hspec . describe "" $ do
-    it "Releases a spot in the pool when there is a query error" $ withManagedPool config $ \pool -> do
+    it "Releases a spot in the pool when there is a query error" $ withPoolConf config $ \pool -> do
       use pool badQuerySession `shouldNotReturn` (Right ())
       use pool selectOneSession `shouldReturn` (Right 1)
-    it "Simulation of connection error works" $ withManagedPool config $ \pool -> do
+    it "Simulation of connection error works" $ withPoolConf config $ \pool -> do
       res <- use pool $ closeConnSession >> selectOneSession
       shouldSatisfy res $ \case
         Left (SessionUsageError (Session.QueryError _ _ (Session.ClientError _))) -> True
         _ -> False
-    it "Connection errors cause eviction of connection" $ withManagedPool config $ \pool -> do
+    it "Connection errors cause eviction of connection" $ withPoolConf config $ \pool -> do
       res <- use pool $ closeConnSession >> selectOneSession
       res <- use pool $ closeConnSession >> selectOneSession
       res <- use pool $ closeConnSession >> selectOneSession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
-    it "Connection gets returned to the pool after normal use" $ withManagedPool config $ \pool -> do
+    it "Connection gets returned to the pool after normal use" $ withPoolConf config $ \pool -> do
       res <- use pool $ selectOneSession
       res <- use pool $ selectOneSession
       res <- use pool $ selectOneSession
       res <- use pool $ selectOneSession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
-    it "Connection gets returned to the pool after non-connection error" $ withManagedPool config $ \pool -> do
+    it "Connection gets returned to the pool after non-connection error" $ withPoolConf config $ \pool -> do
       res <- use pool $ badQuerySession
       res <- use pool $ badQuerySession
       res <- use pool $ badQuerySession
       res <- use pool $ badQuerySession
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
-    it "The pool remains usable after release" $ withManagedPool config $ \pool -> do
+    it "The pool remains usable after release" $ withPoolConf config $ \pool -> do
       res <- use pool $ selectOneSession
       release pool
       res <- use pool $ selectOneSession
       shouldSatisfy res $ isRight
-    it "Getting and setting session variables works" $ withManagedPool config $ \pool -> do
+    it "Getting and setting session variables works" $ withPoolConf config $ \pool -> do
       res <- use pool $ getSettingSession "testing.foo"
       res `shouldBe` Right Nothing
       res <- use pool $ do
         setSettingSession "testing.foo" "hello world"
         getSettingSession "testing.foo"
       res `shouldBe` Right (Just "hello world")
-    it "Session variables stay set when a connection gets reused" $ withManagedPool (setSize 1 config) $ \pool -> do
+    it "Session variables stay set when a connection gets reused" $ withPoolConf (setSize 1 config) $ \pool -> do
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
       res2 `shouldBe` Right (Just "hello world")
-    it "Releasing the pool resets session variables" $ withManagedPool (setSize 1 config) $ \pool -> do
+    it "Releasing the pool resets session variables" $ withPoolConf (setSize 1 config) $ \pool -> do
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
       release pool
@@ -73,7 +73,7 @@ main = do
       res `shouldBe` Right Nothing
     it "Times out connection acquisition" $
         -- 1ms timeout
-        withManagedPool (setSize 1 . setAcquisitionTimeout (Just 1000) $ config) $ \pool -> do
+        withPoolConf (setSize 1 . setAcquisitionTimeout (Just 1000) $ config) $ \pool -> do
       sleeping <- newEmptyMVar
       t0 <- getCurrentTime
       res <-
@@ -92,7 +92,7 @@ main = do
       diffUTCTime t1 t0 `shouldSatisfy` (< 0.5) -- 0.5s
     it "Passively times out old connections" $
         -- 0.5s connection lifetime
-        withManagedPool (setSize 1 . setMaxLifetime (Just 500000) $ config) $ \pool -> do
+        withPoolConf (setSize 1 . setMaxLifetime (Just 500000) $ config) $ \pool -> do
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
@@ -102,13 +102,13 @@ main = do
       res3 `shouldBe` Right Nothing
     it "Counts active connections" $ do
       (taggedConnectionSettings, appName) <- tagConnection connectionSettings
-      withManagedPool (setConnectionSettings taggedConnectionSettings config) $ \pool -> do
+      withPoolConf (setConnectionSettings taggedConnectionSettings config) $ \pool -> do
         res <- use pool $ countConnectionsSession appName
         res `shouldBe` Right 1
     it "Times out old connections" $ do
-      withManagedPool config $ \countPool -> do
+      withPoolConf config $ \countPool -> do
         (taggedConnectionSettings, appName) <- tagConnection connectionSettings
-        withManagedPool
+        withPoolConf
           (setManageInterval 10000 . setMaxLifetime (Just 500000) . setConnectionSettings taggedConnectionSettings $ config)
           (\limitedPool -> do
             res <- use limitedPool $ selectOneSession

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,7 +17,7 @@ import Prelude
 
 main = do
   connectionSettings <- getConnectionSettings
-  let config = setCapacity 3 . setConnectionSettings connectionSettings $ defaultConfig
+  let config = setSize 3 . setConnectionSettings connectionSettings $ defaultConfig
 
   hspec . describe "" $ do
     it "Releases a spot in the pool when there is a query error" $ withManagedPool config $ \pool -> do
@@ -60,12 +60,12 @@ main = do
         setSettingSession "testing.foo" "hello world"
         getSettingSession "testing.foo"
       res `shouldBe` Right (Just "hello world")
-    it "Session variables stay set when a connection gets reused" $ withManagedPool (setCapacity 1 config) $ \pool -> do
+    it "Session variables stay set when a connection gets reused" $ withManagedPool (setSize 1 config) $ \pool -> do
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"
       res2 `shouldBe` Right (Just "hello world")
-    it "Releasing the pool resets session variables" $ withManagedPool (setCapacity 1 config) $ \pool -> do
+    it "Releasing the pool resets session variables" $ withManagedPool (setSize 1 config) $ \pool -> do
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
       release pool
@@ -73,7 +73,7 @@ main = do
       res `shouldBe` Right Nothing
     it "Times out connection acquisition" $
         -- 1ms timeout
-        withManagedPool (setCapacity 1 . setAcquisitionTimeout (Just 1000) $ config) $ \pool -> do
+        withManagedPool (setSize 1 . setAcquisitionTimeout (Just 1000) $ config) $ \pool -> do
       sleeping <- newEmptyMVar
       t0 <- getCurrentTime
       res <-
@@ -92,7 +92,7 @@ main = do
       diffUTCTime t1 t0 `shouldSatisfy` (< 0.5) -- 0.5s
     it "Passively times out old connections" $
         -- 0.5s connection lifetime
-        withManagedPool (setCapacity 1 . setMaxLifetime (Just 500000) $ config) $ \pool -> do
+        withManagedPool (setSize 1 . setMaxLifetime (Just 500000) $ config) $ \pool -> do
       res <- use pool $ setSettingSession "testing.foo" "hello world"
       res `shouldBe` Right ()
       res2 <- use pool $ getSettingSession "testing.foo"


### PR DESCRIPTION
We're seeing trouble with PostgREST where long-lived connections grow to use large amounts of memory postgresql-server-side: https://github.com/PostgREST/postgrest/issues/2638. (As far as I understand, postgresql caches a variety of things per connection-handler and never releases them.)

It seems to me that putting some arbitrary maximal lifetime on connections is the best way to address this, and is something that's likely to be relevant to other users of  hasql-pool.

Somewhat outdated initial description follows, see below for the current state:

This PR is a quick stab at implementing that, but I'm more than happy to rewrite it or to go with some other approach. The current draft definitely has some issues, particularly:

- The setting interface with two `Maybe Int` for the timeouts is a pain -- should this address #22 and force both to be specified? or maybe introduce some settings datatype with reasonable default values for both?
- This is a little bit different from the 0.5 timeout setting, which would be something like a `maxIdleTime` instead of `maxLifetime`.  (For the issue at hand it seems a `maxLifetime` is more appropriate than a `maxIdleTime`, since if we keep the connections busy an idle timeout would never trigger.) Would it be better to add both settings while we're at it?