### PR TITLE
apply ghcup github workaround

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -32,6 +32,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Workaround runner image issue
+      # https://github.com/actions/runner-images/issues/7061
+      run: sudo chown -R $USER /usr/local/.ghcup
     - name: ghcup
       run: |
         ghcup install ghc ${{ matrix.ghc }}


### PR DESCRIPTION
This is a temporary fix to Linux CI while the base image is buggy. (We might be able to wait this out instead, not sure.)

See https://discourse.haskell.org/t/incident-github-actions-ci-failure-ghcup/5761.