### PR TITLE
Revert ghcup github workaround (no longer necessary)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -32,9 +32,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Workaround runner image issue
-      # https://github.com/actions/runner-images/issues/7061
-      run: sudo chown -R $USER /usr/local/.ghcup
     - name: ghcup
       run: |
         ghcup install ghc ${{ matrix.ghc }}


### PR DESCRIPTION
This reverts commit 7724be104a1251aa3f880509526502702b94de0b (#32).