### PR TITLE
Move to DiffTime for timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Maximal lifetime added for connections. Allows to refresh the connections in time cleaning up the resources.
 - The acquisition timeout is now non-optional.
+- Moved to `DiffTime` for timeouts.
 
 # 0.8.0.7
 

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -71,6 +71,7 @@ library
     , base >=4.11 && <5
     , hasql >=1.6.0.1 && <1.7
     , stm >=2.5 && <3
+    , time >=1.9 && <2
 
 test-suite test
   import:         base-settings

--- a/library/Hasql/Pool.hs
+++ b/library/Hasql/Pool.hs
@@ -56,9 +56,9 @@ data Pool = Pool
 acquire ::
   -- | Pool size.
   Int ->
-  -- | Connection acquisition timeout in microseconds.
+  -- | Connection acquisition timeout.
   DiffTime ->
-  -- | Maximal connection lifetime in microseconds.
+  -- | Maximal connection lifetime.
   DiffTime ->
   -- | Connection settings.
   Connection.Settings ->
@@ -76,9 +76,9 @@ acquire poolSize acqTimeout maxLifetime connectionSettings =
 acquireDynamically ::
   -- | Pool size.
   Int ->
-  -- | Connection acquisition timeout in microseconds.
+  -- | Connection acquisition timeout.
   DiffTime ->
-  -- | Maximal connection lifetime in microseconds.
+  -- | Maximal connection lifetime.
   DiffTime ->
   -- | Action fetching connection settings.
   IO Connection.Settings ->

--- a/library/Hasql/Pool/Prelude.hs
+++ b/library/Hasql/Pool/Prelude.hs
@@ -40,6 +40,7 @@ import Data.Proxy as Exports
 import Data.Ratio as Exports
 import Data.STRef as Exports
 import Data.String as Exports
+import Data.Time as Exports
 import Data.Traversable as Exports
 import Data.Tuple as Exports
 import Data.Unique as Exports


### PR DESCRIPTION
At the moment we specify timeouts in microseconds using `Int`. I see a few problems. The microsecond precision seems like a clear overkill and a usage overhead. Milliseconds or even seconds could be better. Another problem is that the `Int` type carries zero information about what precision we use. So I've given here a go for the DiffTime type.

@robx What's your opinion?