### PR TITLE
Introduce flexible config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.11
+# 1
 
 - Optional observability event stream, which can be interpreted into log records and metrics.
+- Configuration got isolated into a DSL, which will allow to provide new configurations without breaking backward compatibility.
 
 # 0.10.1
 

--- a/hasql-pool.cabal
+++ b/hasql-pool.cabal
@@ -71,10 +71,15 @@ library
   -- cabal-gild: discover src/library/exposed
   exposed-modules:
     Hasql.Pool
+    Hasql.Pool.Config
     Hasql.Pool.Observation
 
   -- cabal-gild: discover src/library/other
-  other-modules: Hasql.Pool.Prelude
+  other-modules:
+    Hasql.Pool.Config.Config
+    Hasql.Pool.Config.Setting
+    Hasql.Pool.Prelude
+
   build-depends:
     base >=4.11 && <5,
     bytestring >=0.10 && <0.14,

--- a/src/library/exposed/Hasql/Pool.hs
+++ b/src/library/exposed/Hasql/Pool.hs
@@ -96,7 +96,7 @@ acquire config = do
     -- When the pool goes out of scope, stop the manager.
     killThread managerTid
 
-  return $ Pool (Config.size config) (Config.connectionStringProvider config) acqTimeoutMicros agingTimeoutNanos maxIdletimeNanos connectionQueue capVar reuseVar reaperRef (Config.observationHandler config)
+  return $ Pool (Config.size config) (Config.connectionSettingsProvider config) acqTimeoutMicros agingTimeoutNanos maxIdletimeNanos connectionQueue capVar reuseVar reaperRef (Config.observationHandler config)
   where
     acqTimeoutMicros =
       div (fromIntegral (diffTimeToPicoseconds (Config.acquisitionTimeout config))) 1_000_000

--- a/src/library/exposed/Hasql/Pool/Config.hs
+++ b/src/library/exposed/Hasql/Pool/Config.hs
@@ -7,8 +7,8 @@ module Hasql.Pool.Config
     Setting.acquisitionTimeout,
     Setting.agingTimeout,
     Setting.idlenessTimeout,
-    Setting.staticConnectionString,
-    Setting.dynamicConnectionString,
+    Setting.staticConnectionSettings,
+    Setting.dynamicConnectionSettings,
     Setting.observationHandler,
   )
 where

--- a/src/library/exposed/Hasql/Pool/Config.hs
+++ b/src/library/exposed/Hasql/Pool/Config.hs
@@ -21,4 +21,4 @@ import Hasql.Pool.Prelude
 -- Latter settings override the preceding in cases of conflicts.
 compile :: [Setting.Setting] -> Config.Config
 compile =
-  foldr ($) Config.standard . fmap Setting.apply
+  foldr ($) Config.defaults . fmap Setting.apply

--- a/src/library/exposed/Hasql/Pool/Config.hs
+++ b/src/library/exposed/Hasql/Pool/Config.hs
@@ -1,0 +1,24 @@
+-- | DSL for construction of configs.
+module Hasql.Pool.Config
+  ( Config.Config,
+    compile,
+    Setting.Setting,
+    Setting.size,
+    Setting.acquisitionTimeout,
+    Setting.agingTimeout,
+    Setting.idlenessTimeout,
+    Setting.staticConnectionString,
+    Setting.dynamicConnectionString,
+    Setting.observationHandler,
+  )
+where
+
+import qualified Hasql.Pool.Config.Config as Config
+import qualified Hasql.Pool.Config.Setting as Setting
+import Hasql.Pool.Prelude
+
+-- | Compile config from a list of settings.
+-- Latter settings override the preceding in cases of conflicts.
+compile :: [Setting.Setting] -> Config.Config
+compile =
+  foldr ($) Config.standard . fmap Setting.apply

--- a/src/library/exposed/Hasql/Pool/Config.hs
+++ b/src/library/exposed/Hasql/Pool/Config.hs
@@ -1,7 +1,7 @@
 -- | DSL for construction of configs.
 module Hasql.Pool.Config
   ( Config.Config,
-    compile,
+    settings,
     Setting.Setting,
     Setting.size,
     Setting.acquisitionTimeout,
@@ -19,6 +19,6 @@ import Hasql.Pool.Prelude
 
 -- | Compile config from a list of settings.
 -- Latter settings override the preceding in cases of conflicts.
-compile :: [Setting.Setting] -> Config.Config
-compile =
+settings :: [Setting.Setting] -> Config.Config
+settings =
   foldr ($) Config.defaults . fmap Setting.apply

--- a/src/library/other/Hasql/Pool/Config/Config.hs
+++ b/src/library/other/Hasql/Pool/Config/Config.hs
@@ -1,5 +1,6 @@
 module Hasql.Pool.Config.Config where
 
+import qualified Hasql.Connection as Connection
 import Hasql.Pool.Observation (Observation)
 import Hasql.Pool.Prelude
 
@@ -9,7 +10,7 @@ data Config = Config
     acquisitionTimeout :: DiffTime,
     agingTimeout :: DiffTime,
     idlenessTimeout :: DiffTime,
-    connectionStringProvider :: IO ByteString,
+    connectionSettingsProvider :: IO Connection.Settings,
     observationHandler :: Observation -> IO ()
   }
 
@@ -21,6 +22,6 @@ defaults =
       acquisitionTimeout = 10,
       agingTimeout = 60 * 60 * 24,
       idlenessTimeout = 60 * 10,
-      connectionStringProvider = pure "postgresql://postgres:postgres@localhost:5432/postgres",
+      connectionSettingsProvider = pure "postgresql://postgres:postgres@localhost:5432/postgres",
       observationHandler = const (pure ())
     }

--- a/src/library/other/Hasql/Pool/Config/Config.hs
+++ b/src/library/other/Hasql/Pool/Config/Config.hs
@@ -14,8 +14,8 @@ data Config = Config
   }
 
 -- | Reasonable defaults, which can be built upon.
-standard :: Config
-standard =
+defaults :: Config
+defaults =
   Config
     { size = 3,
       acquisitionTimeout = 10,

--- a/src/library/other/Hasql/Pool/Config/Config.hs
+++ b/src/library/other/Hasql/Pool/Config/Config.hs
@@ -1,0 +1,26 @@
+module Hasql.Pool.Config.Config where
+
+import Hasql.Pool.Observation (Observation)
+import Hasql.Pool.Prelude
+
+-- | Configufation for Hasql connection pool.
+data Config = Config
+  { size :: Int,
+    acquisitionTimeout :: DiffTime,
+    agingTimeout :: DiffTime,
+    idlenessTimeout :: DiffTime,
+    connectionStringProvider :: IO ByteString,
+    observationHandler :: Observation -> IO ()
+  }
+
+-- | Reasonable defaults, which can be built upon.
+standard :: Config
+standard =
+  Config
+    { size = 3,
+      acquisitionTimeout = 10,
+      agingTimeout = 60 * 60 * 24,
+      idlenessTimeout = 60 * 10,
+      connectionStringProvider = pure "postgresql://postgres:postgres@localhost:5432/postgres",
+      observationHandler = const (pure ())
+    }

--- a/src/library/other/Hasql/Pool/Config/Setting.hs
+++ b/src/library/other/Hasql/Pool/Config/Setting.hs
@@ -1,5 +1,6 @@
 module Hasql.Pool.Config.Setting where
 
+import qualified Hasql.Connection as Connection
 import Hasql.Pool.Config.Config (Config)
 import qualified Hasql.Pool.Config.Config as Config
 import Hasql.Pool.Observation (Observation)
@@ -52,9 +53,9 @@ idlenessTimeout x =
 -- You can use 'Hasql.Connection.settings' to construct it.
 --
 -- @\"postgresql://postgres:postgres@localhost:5432/postgres\"@ by default.
-staticConnectionString :: ByteString -> Setting
-staticConnectionString x =
-  Setting (\config -> config {Config.connectionStringProvider = pure x})
+staticConnectionSettings :: Connection.Settings -> Setting
+staticConnectionSettings x =
+  Setting (\config -> config {Config.connectionSettingsProvider = pure x})
 
 -- | Action providing connection settings.
 --
@@ -64,9 +65,9 @@ staticConnectionString x =
 -- You can use 'Hasql.Connection.settings' to construct it.
 --
 -- @pure \"postgresql://postgres:postgres@localhost:5432/postgres\"@ by default.
-dynamicConnectionString :: IO ByteString -> Setting
-dynamicConnectionString x =
-  Setting (\config -> config {Config.connectionStringProvider = x})
+dynamicConnectionSettings :: IO Connection.Settings -> Setting
+dynamicConnectionSettings x =
+  Setting (\config -> config {Config.connectionSettingsProvider = x})
 
 -- | Observation handler.
 --

--- a/src/library/other/Hasql/Pool/Config/Setting.hs
+++ b/src/library/other/Hasql/Pool/Config/Setting.hs
@@ -1,0 +1,81 @@
+module Hasql.Pool.Config.Setting where
+
+import Hasql.Pool.Config.Config (Config)
+import qualified Hasql.Pool.Config.Config as Config
+import Hasql.Pool.Observation (Observation)
+import Hasql.Pool.Prelude
+
+apply :: Setting -> Config -> Config
+apply (Setting run) = run
+
+-- | A single setting of a config.
+newtype Setting
+  = Setting (Config -> Config)
+
+-- | Pool size.
+--
+-- 3 by default.
+size :: Int -> Setting
+size x =
+  Setting (\config -> config {Config.size = x})
+
+-- | Connection acquisition timeout.
+--
+-- 10 seconds by default.
+acquisitionTimeout :: DiffTime -> Setting
+acquisitionTimeout x =
+  Setting (\config -> config {Config.acquisitionTimeout = x})
+
+-- | Maximal connection lifetime.
+--
+-- Determines how long is available for reuse.
+-- After the timeout passes and an active session is finished the connection will be closed releasing a slot in the pool for a fresh connection to be established.
+--
+-- This is useful as a healthy measure for resetting the server-side caches.
+--
+-- 1 day by default.
+agingTimeout :: DiffTime -> Setting
+agingTimeout x =
+  Setting (\config -> config {Config.agingTimeout = x})
+
+-- | Maximal connection idle time.
+--
+-- How long to keep a connection open when it's not being used.
+--
+-- 10 minutes by default.
+idlenessTimeout :: DiffTime -> Setting
+idlenessTimeout x =
+  Setting (\config -> config {Config.idlenessTimeout = x})
+
+-- | Connection string.
+--
+-- You can use 'Hasql.Connection.settings' to construct it.
+--
+-- @\"postgresql://postgres:postgres@localhost:5432/postgres\"@ by default.
+staticConnectionString :: ByteString -> Setting
+staticConnectionString x =
+  Setting (\config -> config {Config.connectionStringProvider = pure x})
+
+-- | Action providing connection settings.
+--
+-- Gets used each time a connection gets established by the pool.
+-- This may be useful for some authorization models.
+--
+-- You can use 'Hasql.Connection.settings' to construct it.
+--
+-- @pure \"postgresql://postgres:postgres@localhost:5432/postgres\"@ by default.
+dynamicConnectionString :: IO ByteString -> Setting
+dynamicConnectionString x =
+  Setting (\config -> config {Config.connectionStringProvider = x})
+
+-- | Observation handler.
+--
+-- Typically it's used for monitoring the state of the pool via metrics and logging.
+--
+-- If the provided action is not lightweight, it's recommended to use intermediate bufferring via channels like TBQueue to avoid occupying the pool management thread for too long.
+-- E.g., if the action is @'atomically' . 'writeTBQueue' yourQueue@, then reading from it and processing can be done on a separate thread.
+--
+-- @const (pure ())@ by default.
+observationHandler :: (Observation -> IO ()) -> Setting
+observationHandler x =
+  Setting (\config -> config {Config.observationHandler = x})

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -21,7 +21,7 @@ main = do
   let withPool poolSize acqTimeout maxLifetime maxIdletime connectionSettings =
         bracket
           ( acquire
-              ( Config.compile
+              ( Config.settings
                   [ Config.size poolSize,
                     Config.acquisitionTimeout acqTimeout,
                     Config.agingTimeout maxLifetime,

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -26,7 +26,7 @@ main = do
                     Config.acquisitionTimeout acqTimeout,
                     Config.agingTimeout maxLifetime,
                     Config.idlenessTimeout maxIdletime,
-                    Config.staticConnectionString connectionSettings
+                    Config.staticConnectionSettings connectionSettings
                   ]
               )
           )


### PR DESCRIPTION
The point of this is to simplify the interface of the initialization functions and avoid their flavourization (i.e., `acquireDynamically`) by delegating that to configuration. Another important aspect is to make it possible to add new settings to the configuration without the need to bump the major version, thus making the package more stable for the users.

Pinging active users for review. @robx, @steve-chavez, @avanov, @domenkozar.